### PR TITLE
Support existing coveragerc file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,10 +87,15 @@ fi
 
 
 # write omit str list to coverage file
-cat << EOF > "$COV_CONFIG_FILE"
+if [ -n "$4" ] && [ -f "./${COV_CONFIG_FILE}" ]; then
+  >&2 echo "Cannot support both user-provided '$COV_CONFIG_FILE' file along with cov-omit-list configuration."
+  exit 1
+elif [ -n "$4" ]; then
+  cat << EOF > "$COV_CONFIG_FILE"
 [run]
 omit = $4
 EOF
+fi
 
 if [ -f "./pyproject.toml" ] && [ -f "./poetry.lock" ]
 then


### PR DESCRIPTION
Add support for users to provide and use an existing .coveragerc file.

I have already tested this change to the github action in my own projects via my fork of this repository.

Should resolve https://github.com/JotaFan/pycoverage/issues/11